### PR TITLE
[CRB-86] Get transaction fee from on-chain settings

### DIFF
--- a/src/handler/constants.rs
+++ b/src/handler/constants.rs
@@ -59,6 +59,7 @@ pub static REPAYMENT_ORDER_PREFIX: Lazy<String> = Lazy::new(|| {
     s
 });
 
+pub const TX_FEE_KEY: &str = "sawtooth.validator.fee";
 pub const TX_FEE_STRING: &str = "10000000000000000";
 
 pub static TX_FEE: Lazy<Integer> =

--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -29,6 +29,7 @@ pub struct HandlerContext<'tx> {
     // current_state: BTreeMap<State, State>,
     tip: u64,
     gateway_context: zmq::Context,
+    #[cfg(not(all(test, feature = "mock")))]
     local_gateway_sock: zmq::Socket,
     gateway_endpoint: String,
     tx_ctx: &'tx dyn TransactionContext,
@@ -67,6 +68,7 @@ impl<'tx> HandlerContext<'tx> {
         tx_ctx: &'tx dyn TransactionContext,
     ) -> TxnResult<Self> {
         Ok(Self {
+            #[cfg(not(all(test, feature = "mock")))]
             local_gateway_sock: utils::create_socket(
                 &gateway_context,
                 &gateway_endpoint,
@@ -148,6 +150,7 @@ impl<'tx> HandlerContext<'tx> {
             })
     }
 
+    #[cfg(not(all(test, feature = "mock")))]
     fn try_verify_external(&mut self, gateway_command: &str) -> TxnResult<Option<String>> {
         log::warn!("Falling back to external gateway");
         let new_local_sock = utils::create_socket(
@@ -194,6 +197,7 @@ impl<'tx> HandlerContext<'tx> {
         }
     }
 
+    #[cfg(not(all(test, feature = "mock")))]
     pub fn verify(&mut self, gateway_command: &str) -> TxnResult<()> {
         self.local_gateway_sock
             .send(gateway_command, 0)

--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -98,7 +98,7 @@ impl<'tx> HandlerContext<'tx> {
     }
 
     fn find_setting(bytes: &[u8], key: &str) -> TxnResult<Option<String>> {
-        let setting = Setting::parse_from_bytes(&bytes).map_err(|e| {
+        let setting = Setting::parse_from_bytes(bytes).map_err(|e| {
             CCApplyError::InternalError(format!("Failed to parse setting from bytes: {}", e))
         })?;
         for entry in setting.get_entries() {
@@ -127,7 +127,7 @@ impl<'tx> HandlerContext<'tx> {
                     Ok(None)
                 } else {
                     let (_addr, value) = &state[0];
-                    Self::find_setting(&value, key)
+                    Self::find_setting(value, key)
                 }
             }
             Err(e) => Err(e.into()),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -1,7 +1,7 @@
 #![cfg(all(test, feature = "mock"))]
 #![allow(non_snake_case, non_upper_case_globals)]
 
-mod mocked;
+pub mod mocked;
 
 use mocked::{MockSettings, MockTransactionContext};
 use sawtooth_sdk::processor::handler::ApplyError;


### PR DESCRIPTION
We now look for the transaction fee amount under the key `sawtooth.validator.fee`, and if no value is set we fall back to the old, hard-coded default fee.

Requires #6 