### PR TITLE
[CRB-115][CRB-119] Use strong typing and arbitrary precision integers more consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "dashmap",
  "derive_more",
  "enclose",
  "enum_dispatch",
@@ -102,7 +101,6 @@ dependencies = [
  "sawtooth-sdk-creditcoin",
  "serde",
  "serde_cbor",
- "serde_json",
  "sha2",
  "zmq",
 ]
@@ -184,16 +182,6 @@ checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if",
- "num_cpus",
 ]
 
 [[package]]
@@ -411,12 +399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,16 +514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -917,12 +889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
 name = "sawtooth-sdk-creditcoin"
 version = "0.5.1"
 source = "git+https://github.com/gluwa/sawtooth-sdk-rust?branch=dev#b8bf91423f8c2334a9f80f96df8c60d5e8b87ec2"
@@ -1006,17 +972,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ debug = true
 anyhow = "1.0.40"
 chrono = "0.4.19"
 clap = "2.33.3"
-dashmap = "4.0.2"
 derive_more = "0.99.13"
 enum_dispatch = "0.3.6"
 fern = { version = "0.6.0", features = ["colored"] }
@@ -30,7 +29,6 @@ rug = { version = "1.13.0", features = [
 ], default-features = false }
 sawtooth-sdk = { package = "sawtooth-sdk-creditcoin", git = "https://github.com/gluwa/sawtooth-sdk-rust", branch = "dev" }
 serde_cbor = "0.11.1"
-serde_json = "1.0.64"
 sha2 = "0.9.5"
 zmq = "0.9.2"
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1828,7 +1828,7 @@ fn reward(
 
         let mut i = last_block_idx;
         for signature in &signatures {
-            award(tx_ctx, new_formula, i, &signature)?;
+            award(tx_ctx, new_formula, i, signature)?;
             i = (i - BlockNum(1))?;
         }
     }
@@ -1877,9 +1877,7 @@ impl CCTransaction for Housekeeping {
         if block_idx == 0 {
             let head = last_block(request);
 
-            if last_processed_block_idx.clone()
-                + CONFIRMATION_COUNT * 2
-                + BLOCK_REWARD_PROCESSING_COUNT
+            if last_processed_block_idx + CONFIRMATION_COUNT * 2 + BLOCK_REWARD_PROCESSING_COUNT
                 < head
             {
                 reward(request, tx_ctx, ctx, last_processed_block_idx, BlockNum(0))?;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -794,7 +794,7 @@ impl CCTransaction for AddOffer {
             );
         }
 
-        let elapsed = head - start;
+        let elapsed = (head - start)?;
 
         if ask_order.expiration < elapsed {
             bail_transaction!(
@@ -830,7 +830,7 @@ impl CCTransaction for AddOffer {
             );
         }
 
-        let elapsed = head - start;
+        let elapsed = (head - start)?;
 
         if bid_order.expiration < elapsed {
             bail_transaction!(
@@ -928,7 +928,7 @@ impl CCTransaction for AddDealOrder {
                 head
             );
         }
-        let elapsed = head - start;
+        let elapsed = (head - start)?;
 
         if offer.expiration < elapsed {
             bail_transaction!(
@@ -1047,7 +1047,7 @@ impl CCTransaction for CompleteDealOrder {
                 head
             );
         }
-        let elapsed = head - start;
+        let elapsed = (head - start)?;
 
         if deal_order.expiration < elapsed {
             bail_transaction!(
@@ -1277,7 +1277,7 @@ impl CCTransaction for CloseDealOrder {
         }
         let maturity = BlockNum::try_from(&deal_order.maturity)?;
 
-        let ticks = ((head - start) + &maturity) / maturity;
+        let ticks = ((head - start)? + &maturity) / maturity;
 
         let deal_amount = Integer::try_parse(&deal_order.amount)?;
         let deal_interest = Integer::try_parse(&deal_order.interest)?;
@@ -1913,7 +1913,7 @@ impl CCTransaction for Housekeeping {
 
         let tip = last_block(request);
 
-        if block_idx >= tip - CONFIRMATION_COUNT {
+        if block_idx >= (tip - CONFIRMATION_COUNT)? {
             info!("Premature processing");
             return Ok(());
         }
@@ -1922,7 +1922,7 @@ impl CCTransaction for Housekeeping {
         filter(tx_ctx, &ask, |addr, proto| {
             let ask_order = protos::AskOrder::try_parse(proto)?;
             let start = BlockNum::try_from(&ask_order.block)?;
-            let elapsed = block_idx - start;
+            let elapsed = (block_idx - start)?;
             if ask_order.expiration < elapsed {
                 tx_ctx.delete_state_entry(addr)?;
             }
@@ -1933,7 +1933,7 @@ impl CCTransaction for Housekeeping {
         filter(tx_ctx, &bid, |addr, proto| {
             let bid_order = protos::BidOrder::try_parse(proto)?;
             let start = BlockNum::try_from(&bid_order.block)?;
-            let elapsed = block_idx - start;
+            let elapsed = (block_idx - start)?;
             if bid_order.expiration < elapsed {
                 tx_ctx.delete_state_entry(addr)?;
             }
@@ -1944,7 +1944,7 @@ impl CCTransaction for Housekeeping {
         filter(tx_ctx, &offer, |addr, proto| {
             let offer = protos::Offer::try_parse(proto)?;
             let start = BlockNum::try_from(&offer.block)?;
-            let elapsed = block_idx - start;
+            let elapsed = (block_idx - start)?;
             if offer.expiration < elapsed {
                 tx_ctx.delete_state_entry(addr)?;
             }
@@ -1955,7 +1955,7 @@ impl CCTransaction for Housekeeping {
         filter(tx_ctx, &deal, |addr, proto| {
             let deal_order = protos::DealOrder::try_parse(proto)?;
             let start = BlockNum::try_from(&deal_order.block)?;
-            let elapsed = block_idx - start;
+            let elapsed = (block_idx - start)?;
             if deal_order.expiration < elapsed && deal_order.loan_transfer.is_empty() {
                 if ctx.tip() == 0 || ctx.tip() > DEAL_EXP_FIX_BLOCK {
                     let wallet_id = string!(NAMESPACE_PREFIX, WALLET, &deal_order.sighash);
@@ -1978,7 +1978,7 @@ impl CCTransaction for Housekeeping {
         filter(tx_ctx, &repay, |addr, proto| {
             let repayment_order = protos::RepaymentOrder::try_parse(proto)?;
             let start = BlockNum::try_from(&repayment_order.block)?;
-            let elapsed = block_idx - start;
+            let elapsed = (block_idx - start)?;
             if repayment_order.expiration < elapsed && repayment_order.previous_owner.is_empty() {
                 tx_ctx.delete_state_entry(addr)?;
             }
@@ -1989,7 +1989,7 @@ impl CCTransaction for Housekeeping {
         filter(tx_ctx, &fee, |addr, proto| {
             let fee = protos::Fee::try_parse(proto)?;
             let start = BlockNum::try_from(&fee.block)?;
-            let elapsed = block_idx - start;
+            let elapsed = (block_idx - start)?;
 
             if elapsed > YEAR_OF_BLOCKS {
                 let wallet_id = string!(NAMESPACE_PREFIX, WALLET, &fee.sighash);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1788,6 +1788,7 @@ fn reward(
 
     let mut new_formula = false;
 
+    // skipcq: RS-D1000
     // TODO: transitioning
     let s = ctx.get_setting("sawtooth.validator.update1")?;
     if let Some(val) = s {
@@ -1841,6 +1842,7 @@ fn filter(
     prefix: &str,
     mut lister: impl FnMut(&str, &[u8]) -> TxnResult<()>,
 ) -> TxnResult<()> {
+    // skipcq: RS-D1000
     // TODO: Transitioning
 
     let states = tx_ctx.get_state_entries_by_prefix(prefix)?;
@@ -1866,12 +1868,12 @@ impl CCTransaction for Housekeeping {
             PROCESSED_BLOCK_ID,
         );
         let state_data = try_get_state_data(tx_ctx, &processed_block_idx)?.unwrap_or_default();
-        let last_processed_block_idx = if !state_data.is_empty() {
+        let last_processed_block_idx = if state_data.is_empty() {
+            BlockNum::default()
+        } else {
             BlockNum::try_from(str::from_utf8(&state_data).map_err(|e| {
                 InvalidTransaction(format!("State data is not valid UTF-8 : {}", e))
             })?)?
-        } else {
-            BlockNum::default()
         };
 
         if block_idx == 0 {

--- a/src/handler/constants.rs
+++ b/src/handler/constants.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use once_cell::sync::Lazy;
 use rug::Integer;
 
-use super::types::BlockNum;
+use super::types::{BlockNum, Credo};
 
 pub const NAMESPACE: &str = "CREDITCOIN";
 pub const NAMESPACE_PREFIX_LENGTH: usize = 6;
@@ -64,13 +64,13 @@ pub static REPAYMENT_ORDER_PREFIX: Lazy<String> = Lazy::new(|| {
 pub const TX_FEE_KEY: &str = "sawtooth.validator.fee";
 pub const TX_FEE_STRING: &str = "10000000000000000";
 
-pub static TX_FEE: Lazy<Integer> =
-    Lazy::new(|| Integer::from_str_radix(TX_FEE_STRING, 10).unwrap());
+pub static TX_FEE: Lazy<Credo> =
+    Lazy::new(|| Credo(Integer::from_str_radix(TX_FEE_STRING, 10).unwrap()));
 
 pub const REWARD_AMOUNT_STRING: &str = "222000000000000000000";
 
-pub static REWARD_AMOUNT: Lazy<Integer> =
-    Lazy::new(|| Integer::from_str_radix(REWARD_AMOUNT_STRING, 10).unwrap());
+pub static REWARD_AMOUNT: Lazy<Credo> =
+    Lazy::new(|| Credo(Integer::from_str_radix(REWARD_AMOUNT_STRING, 10).unwrap()));
 
 // Error messages
 

--- a/src/handler/constants.rs
+++ b/src/handler/constants.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use once_cell::sync::Lazy;
 use rug::Integer;
 
+use super::types::BlockNum;
+
 pub const NAMESPACE: &str = "CREDITCOIN";
 pub const NAMESPACE_PREFIX_LENGTH: usize = 6;
 pub const MERKLE_ADDRESS_LENGTH: usize = 70;
@@ -23,16 +25,16 @@ pub const SETTINGS_NAMESPACE: &str = "000000";
 pub const PROCESSED_BLOCK_ID: &str = "000000000000000000000000000000000000000000000000000000000000";
 
 pub const INTEREST_MULTIPLIER: u64 = 1000000;
-pub const CONFIRMATION_COUNT: u64 = 30;
-pub const YEAR_OF_BLOCKS: u64 = 60 * 24 * 365;
+pub const CONFIRMATION_COUNT: BlockNum = BlockNum(30);
+pub const YEAR_OF_BLOCKS: BlockNum = BlockNum(60 * 24 * 365);
 
-pub const BLOCKS_IN_PERIOD_UPDATE1: u64 = 2500000;
+pub const BLOCKS_IN_PERIOD_UPDATE1: BlockNum = BlockNum(2500000);
 
-pub const BLOCK_REWARD_PROCESSING_COUNT: u64 = 10;
+pub const BLOCK_REWARD_PROCESSING_COUNT: BlockNum = BlockNum(10);
 
 pub const SKIP_TO_GET_60: usize = 512 / 8 * 2 - 60; // 512 - hash size in bits, 8 - bits in byte, 2 - hex digits for byte, 60 - merkle address length (70) without namespace length (6) and prexix length (4)
 
-pub const DEAL_EXP_FIX_BLOCK: u64 = 278890;
+pub const DEAL_EXP_FIX_BLOCK: BlockNum = BlockNum(278890);
 
 pub const GATEWAY_TIMEOUT: i32 = 5000;
 pub const EXTERNAL_GATEWAY_TIMEOUT: i32 = 25000;

--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -264,6 +264,7 @@ mod tests {
     use crate::handler::{
         constants::{TX_FEE, TX_FEE_KEY},
         tests::mocked::MockTransactionContext,
+        types::Credo,
     };
     use sawtooth_sdk::messages::Message;
     #[test]
@@ -285,7 +286,7 @@ mod tests {
         let context =
             HandlerContext::create(zmq_context, "tcp://dummy:8080".into(), &mock_tx_ctx).unwrap();
         let result = context.tx_fee().unwrap().clone();
-        assert_eq!(result, 1u64);
+        assert_eq!(result, Credo(1.into()));
     }
     #[test]
     fn tx_fee_falls_back_to_default() {

--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -83,6 +83,7 @@ impl<'tx> HandlerContext<'tx> {
     }
 
     pub fn sighash(&self, request: &TpProcessRequest) -> TxnResult<SigHash> {
+        // skipcq: RS-D1000
         // TODO: transitioning
         let signer = request.get_header().get_signer_public_key();
         let compressed = utils::compress(signer)?;
@@ -91,6 +92,7 @@ impl<'tx> HandlerContext<'tx> {
     }
 
     pub fn guid(&self, request: &TpProcessRequest) -> Guid {
+        // skipcq: RS-D1000
         // TODO: transitioning
         Guid(request.get_header().get_nonce().to_owned())
     }

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -26,7 +26,7 @@ use crate::handler::utils::{self, calc_interest};
 use crate::{protos, string};
 
 use super::context::mocked::MockHandlerContext;
-use super::types::{Address, BlockNum, TxnResult};
+use super::types::{Address, BlockNum, Credo, CurrencyAmount, TxnResult};
 use super::AddAskOrder;
 use super::AddBidOrder;
 use super::AddDealOrder;
@@ -415,7 +415,7 @@ fn add_ask_order_accept() {
         amount_str: 1.to_string(),
         interest: 2.to_string(),
         maturity: 3.to_string(),
-        fee: 4.to_string(),
+        fee_str: 4.to_string(),
         expiration: 5.into(),
     };
     deserialize_success(args, expected.clone());
@@ -430,7 +430,7 @@ fn add_ask_order_case_insensitive() {
         amount_str: 1.to_string(),
         interest: 2.to_string(),
         maturity: 3.to_string(),
-        fee: 4.to_string(),
+        fee_str: 4.to_string(),
         expiration: 5.into(),
     };
     deserialize_success(args, expected);
@@ -555,7 +555,7 @@ fn add_bid_order_accept() {
         amount_str: 1.to_string(),
         interest: 2.to_string(),
         maturity: 3.to_string(),
-        fee: 4.to_string(),
+        fee_str: 4.to_string(),
         expiration: 5.into(),
     };
     deserialize_success(args, expected.clone());
@@ -570,7 +570,7 @@ fn add_bid_order_case_insensitive() {
         amount_str: 1.to_string(),
         interest: 2.to_string(),
         maturity: 3.to_string(),
-        fee: 4.to_string(),
+        fee_str: 4.to_string(),
         expiration: 5.into(),
     };
     deserialize_success(args, expected);
@@ -949,7 +949,7 @@ fn add_repayment_order_accept() {
     let expected = AddRepaymentOrder {
         deal_order_id: "orderid".into(),
         address_id: "addressid".into(),
-        amount: "1".into(),
+        amount_str: "1".into(),
         expiration: 2.into(),
     };
     deserialize_success(
@@ -967,7 +967,7 @@ fn add_repayment_order_case_insensitive() {
     let expected = AddRepaymentOrder {
         deal_order_id: "orderid".into(),
         address_id: "addressid".into(),
-        amount: "1".into(),
+        amount_str: "1".into(),
         expiration: 2.into(),
     };
     deserialize_success(
@@ -1573,7 +1573,7 @@ fn register_transfer_success() {
         src_address: dst_address_id.clone(),
         dst_address: src_address_id.clone(),
         order: command.order_id.clone(),
-        amount: (command.gain.clone() + 1u64).to_string(),
+        amount: (command.gain.clone() + 1).to_string(),
         tx: command.blockchain_tx_id.clone(),
         sighash: my_sighash.to_string(),
         block: 0.to_string(),
@@ -1611,7 +1611,7 @@ fn add_ask_order_success() {
         amount_str: "1000".into(),
         interest: "10000".into(),
         maturity: "100".into(),
-        fee: "1".into(),
+        fee_str: "1".into(),
         expiration: 10000.into(),
     };
 
@@ -1655,7 +1655,7 @@ fn add_ask_order_success() {
         amount: command.amount_str.clone(),
         interest: command.interest.clone(),
         maturity: command.maturity.clone(),
-        fee: command.fee.clone(),
+        fee: command.fee_str.clone(),
         expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         sighash: my_sighash.to_string(),
@@ -1687,7 +1687,7 @@ fn add_bid_order_success() {
         amount_str: "1000".into(),
         interest: "10000".into(),
         maturity: "100".into(),
-        fee: "1".into(),
+        fee_str: "1".into(),
         expiration: 10000.into(),
     };
 
@@ -1731,7 +1731,7 @@ fn add_bid_order_success() {
         amount: command.amount_str.clone(),
         interest: command.interest.clone(),
         maturity: command.maturity.clone(),
-        fee: command.fee.clone(),
+        fee: command.fee_str.clone(),
         expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         sighash: my_sighash.to_string(),
@@ -1969,7 +1969,7 @@ fn add_deal_order_success() {
 
     // Make sure the fundraiser has enough wallet balance to cover the bid order fee + standard txn fee
     let wallet_id = WalletId::from(&my_sighash);
-    let balance = Integer::try_parse(&bid_order.fee).unwrap() + &*TX_FEE;
+    let balance = Credo::try_parse(&bid_order.fee).unwrap() + &*TX_FEE;
     expect!(tx_ctx, get balance at wallet_id -> Some(balance));
 
     // Construct the deal order
@@ -2109,7 +2109,7 @@ fn complete_deal_order_success() {
     );
 
     let wallet_id = WalletId::from(&my_sighash);
-    let fee = &*TX_FEE - Integer::try_parse(&deal_order.fee).unwrap();
+    let fee = TX_FEE.clone() - Credo::try_parse(&deal_order.fee).unwrap();
     expect!(tx_ctx, get balance at wallet_id -> Some(fee));
 
     let updated_transfer = protos::Transfer {
@@ -2445,7 +2445,7 @@ fn add_repayment_order_success() {
     let command = AddRepaymentOrder {
         deal_order_id: "dealorderid".into(),
         address_id: "buyeraddressid".into(),
-        amount: 5.to_string(),
+        amount_str: 5.to_string(),
         expiration: 10000.into(),
     };
 
@@ -2532,7 +2532,7 @@ fn add_repayment_order_success() {
         blockchain: src_address.blockchain,
         src_address: command.address_id.clone(),
         dst_address: deal_order.src_address,
-        amount: command.amount.clone(),
+        amount: command.amount_str.clone(),
         expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         deal: command.deal_order_id.clone(),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -26,7 +26,7 @@ use crate::handler::utils::{self, calc_interest};
 use crate::{protos, string};
 
 use super::context::mocked::MockHandlerContext;
-use super::types::{Address, TxnResult};
+use super::types::{Address, BlockNum, TxnResult};
 use super::AddAskOrder;
 use super::AddBidOrder;
 use super::AddDealOrder;
@@ -416,7 +416,7 @@ fn add_ask_order_accept() {
         interest: 2.to_string(),
         maturity: 3.to_string(),
         fee: 4.to_string(),
-        expiration: 5,
+        expiration: 5.into(),
     };
     deserialize_success(args, expected.clone());
     deserialize_success(args_uppercase, expected.clone());
@@ -431,7 +431,7 @@ fn add_ask_order_case_insensitive() {
         interest: 2.to_string(),
         maturity: 3.to_string(),
         fee: 4.to_string(),
-        expiration: 5,
+        expiration: 5.into(),
     };
     deserialize_success(args, expected);
 }
@@ -504,7 +504,7 @@ fn add_ask_order_invalid_fee() {
 fn add_ask_order_negative_expiration() {
     deserialize_failure(
         SixArgCommand::new("AddAskOrder", "addressid", 1, 2, 3, 4, -5),
-        INVALID_NUMBER_ERR,
+        NEGATIVE_NUMBER_ERR,
     );
 }
 
@@ -556,7 +556,7 @@ fn add_bid_order_accept() {
         interest: 2.to_string(),
         maturity: 3.to_string(),
         fee: 4.to_string(),
-        expiration: 5,
+        expiration: 5.into(),
     };
     deserialize_success(args, expected.clone());
     deserialize_success(args_uppercase, expected.clone());
@@ -571,7 +571,7 @@ fn add_bid_order_case_insensitive() {
         interest: 2.to_string(),
         maturity: 3.to_string(),
         fee: 4.to_string(),
-        expiration: 5,
+        expiration: 5.into(),
     };
     deserialize_success(args, expected);
 }
@@ -644,7 +644,7 @@ fn add_bid_order_invalid_fee() {
 fn add_bid_order_negative_expiration() {
     deserialize_failure(
         SixArgCommand::new("AddBidOrder", "addressid", 1, 2, 3, 4, -5),
-        INVALID_NUMBER_ERR,
+        NEGATIVE_NUMBER_ERR,
     );
 }
 
@@ -694,7 +694,7 @@ fn add_offer_accept() {
     let expected = AddOffer {
         ask_order_id: "askorder".into(),
         bid_order_id: "bidorder".into(),
-        expiration: 1,
+        expiration: 1.into(),
     };
     deserialize_success(args, expected.clone());
     deserialize_success(args_upper, expected);
@@ -706,7 +706,7 @@ fn add_offer_case_insensitive() {
     let expected = AddOffer {
         ask_order_id: "askorder".into(),
         bid_order_id: "bidorder".into(),
-        expiration: 1,
+        expiration: 1.into(),
     };
     deserialize_success(args, expected);
 }
@@ -715,7 +715,7 @@ fn add_offer_case_insensitive() {
 fn add_offer_negative_expiration() {
     deserialize_failure(
         ThreeArgCommand::new("AddOffer", "ask", "bid", -2),
-        INVALID_NUMBER_ERR,
+        NEGATIVE_NUMBER_ERR,
     );
 }
 
@@ -746,7 +746,7 @@ fn add_offer_missing_arg() {
 fn add_deal_order_accept() {
     let expected = AddDealOrder {
         offer_id: "offerid".into(),
-        expiration: 1,
+        expiration: 1.into(),
     };
     deserialize_success(
         TwoArgCommand::new("AddDealOrder", "offerid", 1),
@@ -759,7 +759,7 @@ fn add_deal_order_accept() {
 fn add_deal_order_case_insensitive() {
     let expected = AddDealOrder {
         offer_id: "offerid".into(),
-        expiration: 1,
+        expiration: 1.into(),
     };
     deserialize_success(TwoArgCommand::new("AdDdEaLoRdEr", "offerid", 1), expected);
 }
@@ -768,7 +768,7 @@ fn add_deal_order_case_insensitive() {
 fn add_deal_order_negative_expiration() {
     deserialize_failure(
         TwoArgCommand::new("AddDealOrder", "offerid", -1),
-        INVALID_NUMBER_ERR,
+        NEGATIVE_NUMBER_ERR,
     );
 }
 
@@ -950,7 +950,7 @@ fn add_repayment_order_accept() {
         deal_order_id: "orderid".into(),
         address_id: "addressid".into(),
         amount: "1".into(),
-        expiration: 2,
+        expiration: 2.into(),
     };
     deserialize_success(
         FourArgCommand::new("AddRepaymentOrder", "orderid", "addressid", 1, 2),
@@ -968,7 +968,7 @@ fn add_repayment_order_case_insensitive() {
         deal_order_id: "orderid".into(),
         address_id: "addressid".into(),
         amount: "1".into(),
-        expiration: 2,
+        expiration: 2.into(),
     };
     deserialize_success(
         FourArgCommand::new("AdDrEpAyMeNtOrDeR", "orderid", "addressid", 1, 2),
@@ -1192,7 +1192,7 @@ fn housekeeping_negative_block_idx() {
 fn housekeeping_invalid_block_idx() {
     deserialize_failure(
         OneArgCommand::new("Housekeeping", "BAD"),
-        INVALID_NUMBER_FORMAT_ERR,
+        INVALID_NUMBER_ERR,
     );
 }
 
@@ -1612,7 +1612,7 @@ fn add_ask_order_success() {
         interest: "10000".into(),
         maturity: "100".into(),
         fee: "1".into(),
-        expiration: 10000,
+        expiration: 10000.into(),
     };
 
     let request = TpProcessRequest {
@@ -1656,7 +1656,7 @@ fn add_ask_order_success() {
         interest: command.interest.clone(),
         maturity: command.maturity.clone(),
         fee: command.fee.clone(),
-        expiration: command.expiration,
+        expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         sighash: my_sighash.to_string(),
     };
@@ -1688,7 +1688,7 @@ fn add_bid_order_success() {
         interest: "10000".into(),
         maturity: "100".into(),
         fee: "1".into(),
-        expiration: 10000,
+        expiration: 10000.into(),
     };
 
     let request = TpProcessRequest {
@@ -1732,7 +1732,7 @@ fn add_bid_order_success() {
         interest: command.interest.clone(),
         maturity: command.maturity.clone(),
         fee: command.fee.clone(),
-        expiration: command.expiration,
+        expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         sighash: my_sighash.to_string(),
     };
@@ -1762,11 +1762,11 @@ fn add_offer_success() {
     let command = AddOffer {
         ask_order_id: "askorderid".into(),
         bid_order_id: "bidorderid".into(),
-        expiration: 10000,
+        expiration: 10000.into(),
     };
 
     let request = TpProcessRequest {
-        tip: 1,
+        tip: 5,
         ..Default::default()
     };
 
@@ -1850,7 +1850,7 @@ fn add_offer_success() {
         blockchain: src_address_proto.blockchain.clone(),
         ask_order: command.ask_order_id.clone(),
         bid_order: command.bid_order_id.clone(),
-        expiration: command.expiration,
+        expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         sighash: my_sighash.to_string(),
     };
@@ -1860,7 +1860,7 @@ fn add_offer_success() {
         vec![
             (offer_address.into(), offer.to_bytes()),
             (wallet_id.to_string(), wallet_with(Some(0)).unwrap()),
-            make_fee(&guid, &my_sighash, None),
+            make_fee(&guid, &my_sighash, Some(request.tip - 1)),
         ],
     );
 
@@ -1875,7 +1875,7 @@ fn add_deal_order_success() {
 
     let command = AddDealOrder {
         offer_id: "someofferid".into(),
-        expiration: 10000,
+        expiration: 10000.into(),
     };
 
     let request = TpProcessRequest {
@@ -1981,7 +1981,7 @@ fn add_deal_order_success() {
         interest: bid_order.interest,
         maturity: bid_order.maturity,
         fee: bid_order.fee,
-        expiration: command.expiration,
+        expiration: command.expiration.into(),
         sighash: my_sighash.to_string(),
         block: (request.tip - 1).to_string(),
         ..Default::default()
@@ -2446,7 +2446,7 @@ fn add_repayment_order_success() {
         deal_order_id: "dealorderid".into(),
         address_id: "buyeraddressid".into(),
         amount: 5.to_string(),
-        expiration: 10000,
+        expiration: 10000.into(),
     };
 
     let request = TpProcessRequest {
@@ -2533,7 +2533,7 @@ fn add_repayment_order_success() {
         src_address: command.address_id.clone(),
         dst_address: deal_order.src_address,
         amount: command.amount.clone(),
-        expiration: command.expiration,
+        expiration: command.expiration.into(),
         block: (request.tip - 1).to_string(),
         deal: command.deal_order_id.clone(),
         sighash: my_sighash.to_string(),
@@ -2821,7 +2821,7 @@ fn housekeeping_reward_in_chain() {
 
     // Housekeeeping with block idx = 0
     let command = Housekeeping {
-        block_idx: Integer::new(),
+        block_idx: BlockNum(0),
     };
 
     // Chain tip is far ahead
@@ -2906,7 +2906,7 @@ fn housekeeping_reward_fork() {
 
     // Housekeeeping with block idx = 0
     let command = Housekeeping {
-        block_idx: Integer::new(),
+        block_idx: BlockNum(0),
     };
 
     let last_processed = CONFIRMATION_COUNT * 2 + BLOCK_REWARD_PROCESSING_COUNT;
@@ -3010,7 +3010,7 @@ fn housekeeping_not_enough_confirmations() {
 
     // Housekeeeping with block idx = 0
     let command = Housekeeping {
-        block_idx: Integer::new(),
+        block_idx: BlockNum(0),
     };
 
     // no blocks have been processed
@@ -3044,7 +3044,7 @@ fn housekeeping_within_block_reward_count() {
 
     // Housekeeeping with block idx = 0
     let command = Housekeeping {
-        block_idx: Integer::new(),
+        block_idx: BlockNum(0),
     };
 
     // pretend we've issued some rewards already

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -2826,7 +2826,7 @@ fn housekeeping_reward_in_chain() {
 
     // Chain tip is far ahead
     let request = TpProcessRequest {
-        tip: (CONFIRMATION_COUNT * 2 + BLOCK_REWARD_PROCESSING_COUNT) * 4,
+        tip: u64::from((CONFIRMATION_COUNT * 2 + BLOCK_REWARD_PROCESSING_COUNT) * 4),
         ..Default::default()
     };
     let mut tx_ctx = MockTransactionContext::default();
@@ -2854,7 +2854,7 @@ fn housekeeping_reward_in_chain() {
     // housekeeping tries to get the signatures for the blocks
     // from height_start to height_end in order to issue mining rewards
     // return a dummy signer
-    for height in height_start..height_end {
+    for height in height_start.0..height_end.0 {
         let signer = format!("signer{}", height);
         signers.push(signer.clone());
         expect!(tx_ctx,
@@ -2892,7 +2892,7 @@ fn housekeeping_reward_in_chain() {
     // which in this case is height_end - 1
     expect!(tx_ctx, set_state_entry(
             addr if addr == PROCESSED_BLOCK_IDX.as_str(),
-            state if state == &(height_end - 1).to_string().into_bytes()
+            state if state == &(height_end - 1).unwrap().to_string().into_bytes()
         ) -> Ok(())
     );
 
@@ -2913,7 +2913,7 @@ fn housekeeping_reward_fork() {
 
     // Chain tip is far ahead
     let request = TpProcessRequest {
-        tip: last_processed * 4,
+        tip: u64::from(last_processed * 4),
         block_signature: "headblocksig".into(),
         ..Default::default()
     };
@@ -2942,7 +2942,7 @@ fn housekeeping_reward_fork() {
 
     log::warn!("{}..{}", last_pred, first_pred);
 
-    let signers: Vec<String> = (last_pred..first_pred)
+    let signers: Vec<String> = (last_pred.0..first_pred.0)
         .map(|i| format!("signer{}", i))
         .collect();
 
@@ -3019,7 +3019,7 @@ fn housekeeping_not_enough_confirmations() {
     // Chain tip is not quite at the threshold for running because
     // the blocks have not yet gotten enough confirmations
     let request = TpProcessRequest {
-        tip: BLOCK_REWARD_PROCESSING_COUNT + 1,
+        tip: u64::from(BLOCK_REWARD_PROCESSING_COUNT + 1),
         block_signature: "headblocksig".into(),
         ..Default::default()
     };
@@ -3053,7 +3053,9 @@ fn housekeeping_within_block_reward_count() {
     // Chain tip is not quite at the threshold for running because
     // fewer than BLOCK_REWARD_PROCESSING_COUNT additional blocks have been processed
     let request = TpProcessRequest {
-        tip: last_processed + BLOCK_REWARD_PROCESSING_COUNT - 1,
+        tip: (last_processed + BLOCK_REWARD_PROCESSING_COUNT.0 - 1)
+            .unwrap()
+            .into(),
         block_signature: "headblocksig".into(),
         ..Default::default()
     };

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -1,8 +1,13 @@
+use std::convert::TryFrom;
 use std::fmt;
+use std::ops::Add;
 use std::ops::Deref;
+use std::ops::Div;
+use std::ops::Sub;
 
 use derive_more::{From, Into};
-use rug::Integer;
+use rug::integer::SmallInteger;
+
 use sawtooth_sdk::processor::handler::ApplyError;
 use sawtooth_sdk::processor::handler::ContextError;
 
@@ -178,8 +183,121 @@ impl AsRef<[u8]> for State {
 
 pub type StateVec = Vec<(String, Vec<u8>)>;
 
-// #[derive(Shrinkwrap, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, From, Default)]
-// #[from(forward)]
-// pub struct BlockNum(Integer);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Default)]
+pub struct BlockNum(pub u64);
 
-pub type BlockNum = Integer;
+impl BlockNum {
+    pub fn new() -> Self {
+        Self(0)
+    }
+}
+
+impl fmt::Display for BlockNum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl TryFrom<&str> for BlockNum {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        println!("value = {:?}", value);
+        if value.contains('-') {
+            println!("It's negative!");
+            return Err(CCApplyError::InvalidTransaction(NEGATIVE_NUMBER_ERR.into()))?;
+        }
+        Ok(BlockNum(value.parse::<u64>().map_err(|_e| {
+            anyhow::Error::from(CCApplyError::InvalidTransaction(INVALID_NUMBER_ERR.into()))
+        })?))
+    }
+}
+
+impl TryFrom<&String> for BlockNum {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &String) -> Result<Self, Self::Error> {
+        <Self as TryFrom<&str>>::try_from(&*value)
+    }
+}
+
+impl Add<u64> for BlockNum {
+    type Output = BlockNum;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+impl Sub<u64> for BlockNum {
+    type Output = BlockNum;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+impl Add<BlockNum> for BlockNum {
+    type Output = BlockNum;
+
+    fn add(self, rhs: BlockNum) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+impl Add<&BlockNum> for BlockNum {
+    type Output = BlockNum;
+
+    fn add(self, rhs: &BlockNum) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+impl Sub<&BlockNum> for BlockNum {
+    type Output = BlockNum;
+
+    fn sub(self, rhs: &BlockNum) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+impl Sub<BlockNum> for BlockNum {
+    type Output = BlockNum;
+
+    #[track_caller]
+    fn sub(self, rhs: BlockNum) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+impl PartialEq<u64> for BlockNum {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+impl PartialEq<BlockNum> for u64 {
+    fn eq(&self, other: &BlockNum) -> bool {
+        *self == other.0
+    }
+}
+impl PartialOrd<u64> for BlockNum {
+    fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+impl PartialOrd<BlockNum> for u64 {
+    fn partial_cmp(&self, other: &BlockNum) -> Option<std::cmp::Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+impl Div<BlockNum> for BlockNum {
+    type Output = BlockNum;
+
+    fn div(self, rhs: BlockNum) -> Self::Output {
+        Self(self.0 / rhs.0)
+    }
+}
+impl From<BlockNum> for SmallInteger {
+    fn from(value: BlockNum) -> Self {
+        SmallInteger::from(value.0)
+    }
+}
+impl From<BlockNum> for u64 {
+    fn from(value: BlockNum) -> Self {
+        value.0
+    }
+}

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -18,6 +18,7 @@ use crate::handler::constants::{
 use super::constants::INTEREST_MULTIPLIER;
 use super::constants::INVALID_NUMBER_ERR;
 use super::types::BlockNum;
+use super::types::CurrencyAmount;
 use super::types::State;
 use super::types::StateVec;
 use super::types::WalletId;
@@ -275,14 +276,18 @@ pub fn add_fee_state(
     add_state(states, wallet_id.clone().into(), wallet)
 }
 
-pub fn calc_interest(amount: &Integer, ticks: &Integer, interest: &Integer) -> Integer {
+pub fn calc_interest(
+    amount: &CurrencyAmount,
+    ticks: BlockNum,
+    interest: &CurrencyAmount,
+) -> CurrencyAmount {
     let mut total = amount.clone();
-    let mut i = Integer::from(0);
+    let mut i = BlockNum(0);
 
-    while &i < ticks {
+    while i < ticks {
         let compound = (total.clone() * interest) / INTEREST_MULTIPLIER;
         total += compound;
-        i += 1;
+        i += BlockNum(1);
     }
     total
 }

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -205,6 +205,7 @@ pub fn create_socket(
 }
 
 pub fn last_block(request: &TpProcessRequest) -> BlockNum {
+    // skipcq: RS-D1000
     // TODO: transitioning
     let tip = request.get_tip();
     if tip == 0 {


### PR DESCRIPTION
This PR transitions from using primitives to using the newtype pattern for block numbers, credo amounts, and currency amounts. This also served to enforce consistent representations and make it easier to delineate where we need to use arbitrary precision integers. We now use a `u64` to represent block numbers, as sawtooth uses that representation internally and that is what the protobufs require, so there is no benefit to using big integers for block numbers here.

This should also make it easier to refactor or change the underlying representation of these types, as there is only one definition to change and more logic errors are caught at compile-time.

This is based on #7 and should be merged after it.