### PR TITLE
[CRB-189] Handle edge case responses from validators

### DIFF
--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -132,7 +132,10 @@ impl<'tx> HandlerContext<'tx> {
                         Ok(None)
                     }
                     Err(ContextError::ResponseAttributeError(_)) => {
-                        log::debug!("setting not found for key {:?}", key);
+                        log::debug!(
+                            "received response attribute error, setting not found for key {:?}",
+                            key
+                        );
                         Ok(None)
                     }
                     Err(e) => Err(e.into()),

--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -131,7 +131,6 @@ impl<'tx> HandlerContext<'tx> {
                         log::debug!("setting not found for key {:?}", key);
                         Ok(None)
                     }
-                    #[cfg(feature = "old-sawtooth")]
                     Err(ContextError::ResponseAttributeError(_)) => {
                         log::debug!("setting not found for key {:?}", key);
                         Ok(None)

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -225,9 +225,8 @@ pub fn get_state_data<A: AsRef<str>>(
         Ok(data) => data.ok_or_else(|| {
             CCApplyError::InvalidTransaction(format!("Existing state expected {}", address))
         }),
-        #[cfg(feature = "old-sawtooth")]
         Err(sawtooth_sdk::processor::handler::ContextError::AuthorizationError(s)) => {
-            log::warn!("Received authorization error from validator, most likely a misleading error message: {}", s);
+            log::warn!("Received authorization error from validator, the address may be invalid: {}", s);
             Err(CCApplyError::InvalidTransaction(format!(
                 "Existing state expected {}",
                 address

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -74,12 +74,9 @@ pub fn get_string<'a>(
     name: &str,
 ) -> TxnResult<&'a String> {
     match map.get(&Value::Text(key.into())) {
+        Some(Value::Text(text)) => Ok(text),
         Some(value) => {
-            if let Value::Text(s) = value {
-                Ok(s)
-            } else {
-                bail_transaction!("Value for {} was not a string, found : {:?}", name, value)
-            }
+            bail_transaction!("Value for {} was not a string, found : {:?}", name, value)
         }
         None => {
             bail_transaction!("Expecting {}", name)
@@ -226,7 +223,10 @@ pub fn get_state_data<A: AsRef<str>>(
             CCApplyError::InvalidTransaction(format!("Existing state expected {}", address))
         }),
         Err(sawtooth_sdk::processor::handler::ContextError::AuthorizationError(s)) => {
-            log::warn!("Received authorization error from validator, the address may be invalid: {}", s);
+            log::warn!(
+                "Received authorization error from validator, the address may be invalid: {}",
+                s
+            );
             Err(CCApplyError::InvalidTransaction(format!(
                 "Existing state expected {}",
                 address


### PR DESCRIPTION
In my local testing I've found that in some cases validators will return misleading "errors", which we should identify and handle properly. For instance, sometimes validator nodes will return an `AuthorizationError` if we try to access invalid state, which is misleading. Additionally, a `get_states_by_prefix` request on a nonexistent address may result in an `ResponseAttributeError`, rather than `None`.