### PR TITLE
[CRB-202] Add RegisterDealOrder command

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1385,15 +1385,18 @@ impl CCTransaction for RegisterDealOrder {
                 )
             })?;
 
-        let message = utils::sha512_bytes(&string!(
-            self.ask_address_id,
-            self.bid_address_id,
-            self.amount_str,
-            self.interest,
-            self.maturity,
-            self.fee_str,
-            self.expiration.to_string()
-        ));
+        let message = utils::sha512_bytes(
+            [
+                self.ask_address_id.clone(),
+                self.bid_address_id.clone(),
+                self.amount_str.clone(),
+                self.interest.clone(),
+                self.maturity.clone(),
+                self.fee_str.clone(),
+                self.expiration.to_string(),
+            ]
+            .join(","),
+        );
 
         let context = secp256k1::Secp256k1Context::new();
         match context.verify(&self.fundraiser_signature, &message, &public_key) {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1422,19 +1422,17 @@ impl CCTransaction for RegisterDealOrder {
             self.amount_str.as_str(),
         ]
         .join("");
-        let message = utils::sha512_bytes(
-            [
-                first_three,
-                self.interest.clone(),
-                self.maturity.clone(),
-                self.fee_str.clone(),
-                self.expiration.to_string(),
-            ]
-            .join(","),
-        );
+        let message = [
+            first_three,
+            self.interest.clone(),
+            self.maturity.clone(),
+            self.fee_str.clone(),
+            self.expiration.to_string(),
+        ]
+        .join(",");
 
         let context = secp256k1::Secp256k1Context::new();
-        match context.verify(&self.fundraiser_signature, &message, &public_key) {
+        match context.verify(&self.fundraiser_signature, message.as_bytes(), &public_key) {
             Ok(true) => {}
             Ok(false) => {
                 bail_transaction!(

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -362,6 +362,37 @@ impl TryFrom<Value> for CCCommand {
                 }
                 .into(),
 
+                "REGISTERDEALORDER" => {
+                    let ask_address_id = get_string(&map, "p1", "askAddressId")?.to_lowercase();
+                    let bid_address_id = get_string(&map, "p2", "bidAddressId")?.to_lowercase();
+                    let amount_str = get_integer_string(&map, "p3", "amount")?.clone();
+                    let interest = get_integer_string(&map, "p4", "interest")?.clone();
+                    let maturity = get_integer_string(&map, "p5", "maturity")?.clone();
+                    let fee_str = get_integer_string(&map, "p6", "fee")?.to_owned();
+                    let expiration = get_block_num(&map, "p7", "expiration")?;
+                    let fundraiser_signature =
+                        get_string(&map, "p8", "fundraiserSignature")?.clone();
+                    let fundraiser_public_key =
+                        get_string(&map, "p9", "fundraiserPublicKey")?.clone();
+                    let deal_order_id = get_string(&map, "p10", "dealOrderId")?.to_lowercase();
+                    let blockchain_tx_id =
+                        get_string(&map, "p11", "blockchainTxId")?.to_lowercase();
+                    RegisterDealOrder {
+                        ask_address_id,
+                        bid_address_id,
+                        amount_str,
+                        interest,
+                        maturity,
+                        fee_str,
+                        expiration,
+                        fundraiser_signature,
+                        fundraiser_public_key,
+                        deal_order_id,
+                        blockchain_tx_id,
+                    }
+                    .into()
+                }
+
                 _ => bail_transaction!("Invalid verb in parameters: {:?}", verb),
             })
         } else {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1473,7 +1473,7 @@ impl CCTransaction for RegisterDealOrder {
 
         if let Some(transfer) = try_get_state_data(tx_ctx, &transfer_id)? {
             bail_transaction!(
-                "The transaction has already been registered",
+                "The transfer has already been registered",
                 context = "The transfer ID {} is already associated with a transfer {:?}",
                 { transfer_id.as_str() },
                 transfer
@@ -1503,8 +1503,8 @@ impl CCTransaction for RegisterDealOrder {
 
         let deal_order = protos::DealOrder {
             blockchain: ask_address.blockchain,
-            src_address: ask_address.value,
-            dst_address: bid_address.value,
+            src_address: self.ask_address_id.clone(),
+            dst_address: self.bid_address_id.clone(),
             amount: self.amount_str.clone(),
             interest: self.interest,
             maturity: self.maturity,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1416,11 +1416,15 @@ impl CCTransaction for RegisterDealOrder {
                 )
             })?;
 
+        let first_three = [
+            self.ask_address_id.as_str(),
+            self.bid_address_id.as_str(),
+            self.amount_str.as_str(),
+        ]
+        .join("");
         let message = utils::sha512_bytes(
             [
-                self.ask_address_id.clone(),
-                self.bid_address_id.clone(),
-                self.amount_str.clone(),
+                first_three,
                 self.interest.clone(),
                 self.maturity.clone(),
                 self.fee_str.clone(),

--- a/src/handler/constants.rs
+++ b/src/handler/constants.rs
@@ -74,6 +74,5 @@ pub static REWARD_AMOUNT: Lazy<Credo> =
 
 // Error messages
 
-pub const INVALID_NUMBER_ERR: &str = "Invalid number";
 pub const INVALID_NUMBER_FORMAT_ERR: &str = "Invalid number format";
 pub const NEGATIVE_NUMBER_ERR: &str = "Expecting a positive value";

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3456,10 +3456,14 @@ fn register_deal_order_success() {
     let fee_str = "1".to_owned();
     let expiration: BlockNum = 1000.into();
 
-    let signature = [
+    let first_three = [
         ask_address_id.clone(),
         bid_address_id.clone(),
         amount_str.clone(),
+    ]
+    .join("");
+    let signature = [
+        first_three,
         interest.clone(),
         maturity.clone(),
         fee_str.clone(),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3116,7 +3116,12 @@ fn register_deal_order_success() {
         .sign(&utils::sha512_bytes(signature.as_bytes()))
         .unwrap();
 
-    let deal_order_id = [NAMESPACE_PREFIX.clone().as_str(), DEAL_ORDER].join("");
+    let deal_order_id = [
+        NAMESPACE_PREFIX.clone().as_str(),
+        DEAL_ORDER,
+        "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefbeef",
+    ]
+    .join("");
 
     let command = RegisterDealOrder {
         ask_address_id: ask_address_id.clone(),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -517,7 +517,7 @@ fn add_ask_order_negative_expiration() {
 fn add_ask_order_invalid_expiration() {
     deserialize_failure(
         SixArgCommand::new("AddAskOrder", "addressid", 1, 2, 3, 4, "BAD"),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 
@@ -657,7 +657,7 @@ fn add_bid_order_negative_expiration() {
 fn add_bid_order_invalid_expiration() {
     deserialize_failure(
         SixArgCommand::new("AddBidOrder", "addressid", 1, 2, 3, 4, "BAD"),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 
@@ -728,7 +728,7 @@ fn add_offer_negative_expiration() {
 fn add_offer_invalid_expiration() {
     deserialize_failure(
         ThreeArgCommand::new("AddOffer", "ask", "bid", "BAD"),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 
@@ -781,7 +781,7 @@ fn add_deal_order_negative_expiration() {
 fn add_deal_order_invalid_expiration() {
     deserialize_failure(
         TwoArgCommand::new("AddDealOrder", "offerid", "BAD"),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 
@@ -1001,7 +1001,7 @@ fn add_repayment_order_invalid_amount() {
 fn add_repayment_order_invalid_expiration() {
     deserialize_failure(
         FourArgCommand::new("AddRepaymentOrder", "orderid", "addressid", 1, "BAD"),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 
@@ -1197,7 +1197,7 @@ fn housekeeping_negative_block_idx() {
 fn housekeeping_invalid_block_idx() {
     deserialize_failure(
         OneArgCommand::new("Housekeeping", "BAD"),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 
@@ -1447,7 +1447,7 @@ fn register_deal_order_invalid_expiration() {
             "dealorderid",
             "txid",
         ),
-        INVALID_NUMBER_ERR,
+        INVALID_NUMBER_FORMAT_ERR,
     );
 }
 

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3557,8 +3557,8 @@ fn register_deal_order_success() {
 
     let deal_order = protos::DealOrder {
         blockchain: ask_address.blockchain.clone(),
-        src_address: ask_address.value.clone(),
-        dst_address: bid_address.value.clone(),
+        src_address: ask_address_id.clone(),
+        dst_address: bid_address_id.clone(),
         amount: amount_str.clone(),
         interest: interest.clone(),
         maturity: maturity.clone(),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3471,9 +3471,7 @@ fn register_deal_order_success() {
     ]
     .join(",");
 
-    let fundraiser_signature = signer
-        .sign(&utils::sha512_bytes(signature.as_bytes()))
-        .unwrap();
+    let fundraiser_signature = signer.sign(&signature.as_bytes()).unwrap();
 
     let deal_order_id = [
         NAMESPACE_PREFIX.clone().as_str(),

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -233,6 +233,11 @@ command!(Three, P1, P2, P3);
 command!(Four, P1, P2, P3, P4);
 command!(Five, P1, P2, P3, P4, P5);
 command!(Six, P1, P2, P3, P4, P5, P6);
+command!(Seven, P1, P2, P3, P4, P5, P6, P7);
+command!(Eight, P1, P2, P3, P4, P5, P6, P7, P8);
+command!(Nine, P1, P2, P3, P4, P5, P6, P7, P8, P9);
+command!(Ten, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10);
+command!(Eleven, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11);
 
 #[track_caller]
 fn deserialize_success(value: impl Serialize, expected: impl Into<CCCommand>) {
@@ -1199,6 +1204,356 @@ fn housekeeping_invalid_block_idx() {
 #[test]
 fn housekeeping_rejects_missing_arg() {
     deserialize_failure(ZeroArgCommand::new("Housekeeping"), "Expecting blockIdx");
+}
+
+// RegisterDealOrder
+
+#[test]
+fn register_deal_order_accept() {
+    deserialize_success(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        CCCommand::RegisterDealOrder(RegisterDealOrder {
+            ask_address_id: "askaddress".into(),
+            bid_address_id: "bidaddress".into(),
+            amount_str: "1".into(),
+            interest: "1".into(),
+            maturity: "1".into(),
+            fee_str: "1".into(),
+            expiration: 1.into(),
+            fundraiser_signature: "signature".into(),
+            fundraiser_public_key: "pubkey".into(),
+            deal_order_id: "dealorderid".into(),
+            blockchain_tx_id: "txid".into(),
+        }),
+    );
+}
+
+#[test]
+fn register_deal_order_negative_amount_str() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "-1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        NEGATIVE_NUMBER_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_invalid_amount_str() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "BAD",
+            "1",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        INVALID_NUMBER_FORMAT_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_negative_interest() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "-1",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        NEGATIVE_NUMBER_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_invalid_interest() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "BAD",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        INVALID_NUMBER_FORMAT_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_negative_maturity() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "-1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        NEGATIVE_NUMBER_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_invalid_maturity() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "BAD",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        INVALID_NUMBER_FORMAT_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_negative_fee_str() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "-1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        NEGATIVE_NUMBER_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_invalid_fee_str() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "BAD",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        INVALID_NUMBER_FORMAT_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_negative_expiration() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "-1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        NEGATIVE_NUMBER_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_invalid_expiration() {
+    deserialize_failure(
+        ElevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "BAD",
+            "signature",
+            "pubkey",
+            "dealorderid",
+            "txid",
+        ),
+        INVALID_NUMBER_ERR,
+    );
+}
+
+#[test]
+fn register_deal_order_rejects_missing_arg() {
+    deserialize_failure(
+        TenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+            "dealorderid",
+        ),
+        "Expecting blockchainTxId",
+    );
+    deserialize_failure(
+        NineArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "signature",
+            "pubkey",
+        ),
+        "Expecting dealOrderId",
+    );
+    deserialize_failure(
+        EightArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "signature",
+        ),
+        "Expecting fundraiserPublicKey",
+    );
+    deserialize_failure(
+        SevenArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+        ),
+        "Expecting fundraiserSignature",
+    );
+    deserialize_failure(
+        SixArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+            "1",
+        ),
+        "Expecting expiration",
+    );
+    deserialize_failure(
+        FiveArgCommand::new(
+            "RegisterDealOrder",
+            "askaddress",
+            "bidaddress",
+            "1",
+            "1",
+            "1",
+        ),
+        "Expecting fee",
+    );
+    deserialize_failure(
+        FourArgCommand::new("RegisterDealOrder", "askaddress", "bidaddress", "1", "1"),
+        "Expecting maturity",
+    );
+    deserialize_failure(
+        ThreeArgCommand::new("RegisterDealOrder", "askaddress", "bidaddress", "1"),
+        "Expecting interest",
+    );
+    deserialize_failure(
+        TwoArgCommand::new("RegisterDealOrder", "askaddress", "bidaddress"),
+        "Expecting amount",
+    );
+    deserialize_failure(
+        OneArgCommand::new("RegisterDealOrder", "askaddress"),
+        "Expecting bidAddressId",
+    );
+    deserialize_failure(
+        ZeroArgCommand::new("RegisterDealOrder"),
+        "Expecting askAddressId",
+    );
 }
 
 fn make_fee(guid: &Guid, sighash: &SigHash, block: Option<u64>) -> (String, Vec<u8>) {

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -264,6 +264,17 @@ impl Credo {
     }
 }
 
+impl<'a> PartialEq<&'a Credo> for Credo {
+    fn eq(&self, other: &&'a Credo) -> bool {
+        self.0 == other.0
+    }
+}
+impl<'a> PartialOrd<&'a Credo> for Credo {
+    fn partial_cmp(&self, other: &&'a Credo) -> Option<std::cmp::Ordering> {
+        self.partial_cmp(*other)
+    }
+}
+
 impl PartialEq<i64> for Credo {
     fn eq(&self, other: &i64) -> bool {
         self.0.eq(other)

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -171,7 +171,9 @@ impl Address {
                 address,
                 expected_prefix
             );
-        } else if !address.len() == 70 {
+        } else if address.len() != 70 {
+            println!("Bad {:?}", address);
+
             bail_transaction!(
                 "Invalid id",
                 context = "the id {:?} must be 70 characters long, but it is {}",

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -429,7 +429,9 @@ impl TryFrom<&str> for BlockNum {
             return Err(CCApplyError::InvalidTransaction(NEGATIVE_NUMBER_ERR.into()))?;
         }
         Ok(BlockNum(value.parse::<u64>().map_err(|_e| {
-            anyhow::Error::from(CCApplyError::InvalidTransaction(INVALID_NUMBER_ERR.into()))
+            anyhow::Error::from(CCApplyError::InvalidTransaction(
+                INVALID_NUMBER_FORMAT_ERR.into(),
+            ))
         })?))
     }
 }

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -138,6 +138,13 @@ pub fn sha512_id<B: AsRef<[u8]>>(bytes: B) -> String {
     ret.to_owned()
 }
 
+pub fn sha512_bytes<B: AsRef<[u8]>>(bytes: B) -> Vec<u8> {
+    let mut hasher = Sha512::new();
+    hasher.update(bytes);
+    let result = hasher.finalize();
+    result.to_vec()
+}
+
 pub fn sha512<B: AsRef<[u8]>>(bytes: B) -> String {
     let mut hasher = Sha512::new();
     hasher.update(bytes);
@@ -149,7 +156,7 @@ pub fn is_hex(s: &str) -> bool {
     s.contains(|c: char| !(c.is_numeric() || ('a'..'f').contains(&c) || ('A'..'F').contains(&c)))
 }
 
-pub fn compress(uncompressed: &str) -> TxnResult<SigHash> {
+pub fn compress(uncompressed: &str) -> TxnResult<String> {
     let marker = &uncompressed[..2];
     if uncompressed.len() == 2 * (1 + 2 * 32) && is_hex(uncompressed) && marker == "04" {
         let x = &uncompressed[2..][..(2 * 32)];
@@ -164,9 +171,9 @@ pub fn compress(uncompressed: &str) -> TxnResult<SigHash> {
             compressed.push_str("02");
         }
         compressed.push_str(x);
-        Ok(SigHash(compressed))
+        Ok(compressed)
     } else if (marker == "02" || marker == "03") && uncompressed.len() == 66 {
-        Ok(SigHash(uncompressed.to_owned()))
+        Ok(uncompressed.to_owned())
     } else {
         Err(CCApplyError::InvalidTransaction(
             "Unexpected public key format".into(),

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -16,7 +16,7 @@ use crate::handler::constants::{
 };
 
 use super::constants::INTEREST_MULTIPLIER;
-use super::constants::INVALID_NUMBER_ERR;
+use super::constants::INVALID_NUMBER_FORMAT_ERR;
 use super::types::BlockNum;
 use super::types::CurrencyAmount;
 use super::types::State;
@@ -112,7 +112,7 @@ pub fn get_u64(map: &BTreeMap<Value, Value>, key: &str, name: &str) -> TxnResult
     let str_value = get_string(map, key, name)?;
     str_value
         .parse()
-        .map_err(|_| CCApplyError::InvalidTransaction(INVALID_NUMBER_ERR.into()).into())
+        .map_err(|_| CCApplyError::InvalidTransaction(INVALID_NUMBER_FORMAT_ERR.into()).into())
 }
 
 pub fn get_block_num(map: &BTreeMap<Value, Value>, key: &str, name: &str) -> TxnResult<BlockNum> {


### PR DESCRIPTION
This PR implements the RegisterDealOrder command, which creates an simpler entry point for recording loans.

This is based on the changes from #8 and #12, so this is blocked on both of those PRs being merged.