### PR TITLE
[CRB-287] Avoid double lookup when settings are not an input

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2359,6 +2359,7 @@ impl TransactionHandler for CCTransactionHandler {
             self.zmq_context.clone(),
             self.gateway_endpoint.clone(),
             &*context,
+            request,
         )
         .log_err()
         .to_apply_error()?;

--- a/src/handler/context.rs
+++ b/src/handler/context.rs
@@ -105,7 +105,7 @@ impl<'tx> HandlerContext<'tx> {
         log::debug!("getting setting for key {:?}", key);
         let k = make_settings_key(key);
         let inputs = self.request.get_header().get_inputs();
-        let client_request = !inputs.into_iter().any(|s| k.starts_with(s));
+        let client_request = !inputs.iter().any(|s| k.starts_with(s));
         if client_request {
             log::warn!("Falling back to a client request - the settings namespace is not declared as a transaction input");
             let state = self.tx_ctx.get_state_entries_by_prefix("", &k);


### PR DESCRIPTION
## Description Of Changes
This PR implements an optimization to avoid making two requests when we know the first request will fail. Currently we attempt to make a state request for settings (the intended route for retrieving settings), but if the settings namespace is not declared as an input to the transaction the validator returns an error. In the case of an error, we fall back to a client request instead. This means in the worst case we make two requests for the same resource. We have all of the information required to know whether the first request will fail, so this PR uses this to avoid a double lookup in the worst case.

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [x] All CI checks reports PASS

