### PR TITLE
[CRB-288] Normalize sighashes before creating wallet IDs

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -198,7 +198,7 @@ impl TryFrom<Value> for CCCommand {
             Ok(match verb.to_uppercase().as_str() {
                 "SENDFUNDS" => {
                     let amount = Credo(get_integer(&map, "p1", "amount")?);
-                    let sighash = SigHash(get_string(&map, "p2", "sighash")?.clone());
+                    let sighash = SigHash(get_string(&map, "p2", "sighash")?.to_lowercase());
                     SendFunds { amount, sighash }.into()
                 }
 

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -280,7 +280,19 @@ fn send_funds_case_insensitive() {
             amount: 1.into(),
             sighash: SigHash("foo".into()),
         },
-    )
+    );
+
+    let value = value::to_value(TwoArgCommand::new("SendFunds", 1, "Foo-Bar")).unwrap();
+
+    let result = CCCommand::try_from(value).unwrap();
+    assert_eq!(
+        result,
+        SendFunds {
+            amount: 1.into(),
+            sighash: SigHash("foo-bar".into()),
+        }
+        .into(),
+    );
 }
 
 #[test]

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -71,7 +71,7 @@ impl From<&str> for SigHash {
 
 impl SigHash {
     pub fn to_wallet_id(&self) -> WalletId {
-        let wallet_id = string!(NAMESPACE_PREFIX, WALLET, self);
+        let wallet_id = string!(NAMESPACE_PREFIX, WALLET, self.to_lowercase());
         wallet_id.into()
     }
     pub fn from_public_key(key: &str) -> TxnResult<SigHash> {

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -81,6 +81,15 @@ impl SigHash {
     }
 }
 
+#[test]
+fn sighash_to_wallet_id_always_returns_lowercase() {
+    let sighash = SigHash::from("-InvestoR-SighasH");
+    assert_eq!(
+        sighash.to_wallet_id().to_string(),
+        "8a1a040000-investor-sighash"
+    );
+}
+
 impl Deref for SigHash {
     type Target = String;
 


### PR DESCRIPTION
## Description Of Changes
This PR normalizes the case of sighashes passed by users for consistency and correctness. Currently sighashes are not normalized and when a wallet ID is created from a sighash, the resulting ID is not normalized either. Sawtooth, however, expects the ID to be all lowercase hexadecimal, so valid transactions can be rejected if the input sighash is non-lowercased.

This is necessary to be able to validate the production chain, as some legacy blocks do not have fully normalized sighashes and will be incorrectly rejected by the current processor.

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [x] All CI checks reports PASS

