### PR TITLE
[CRB-289] Don't error on overflow in housekeeping (backwards compatibility)

### DIFF
--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3255,7 +3255,7 @@ fn housekeeping_reward_in_chain() {
     // which in this case is height_end - 1
     expect!(tx_ctx, set_state_entry(
             addr if addr == PROCESSED_BLOCK_IDX.as_str(),
-            state if state == &(height_end - 1).unwrap().to_string().into_bytes()
+            state if state == &(height_end - 1).to_string().into_bytes()
         ) -> Ok(())
     );
 
@@ -3398,6 +3398,7 @@ fn housekeeping_not_enough_confirmations() {
 
 #[test]
 fn housekeeping_within_block_reward_count() {
+    use std::convert::TryInto;
     init_logs();
 
     // Housekeeeping with block idx = 0
@@ -3412,8 +3413,9 @@ fn housekeeping_within_block_reward_count() {
     // fewer than BLOCK_REWARD_PROCESSING_COUNT additional blocks have been processed
     let request = TpProcessRequest {
         tip: (last_processed + BLOCK_REWARD_PROCESSING_COUNT.0 - 1)
-            .unwrap()
-            .into(),
+            .0
+            .try_into()
+            .unwrap(),
         block_signature: "headblocksig".into(),
         ..Default::default()
     };

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -561,26 +561,20 @@ impl Add<u64> for BlockNum {
     }
 }
 impl Sub<u64> for BlockNum {
-    type Output = TxnResult<BlockNum>;
+    type Output = BlockInterval;
 
     fn sub(self, rhs: u64) -> Self::Output {
-        Ok(Self(self.0.checked_sub(rhs).ok_or_else(|| {
-            CCApplyError::InvalidTransaction(
-                "The subtraction would have resulted in overflow".into(),
-            )
-        })?))
+        let rhs = BlockNum(rhs);
+        self.sub(rhs)
     }
 }
 
 impl Sub<BlockNum> for BlockNum {
-    type Output = TxnResult<BlockNum>;
+    type Output = BlockInterval;
 
     fn sub(self, rhs: BlockNum) -> Self::Output {
-        Ok(Self(self.0.checked_sub(rhs.0).ok_or_else(|| {
-            CCApplyError::InvalidTransaction(
-                "The subtraction would have resulted in overflow".into(),
-            )
-        })?))
+        let diff = i128::from(self.0) - i128::from(rhs.0);
+        BlockInterval(diff)
     }
 }
 

--- a/src/handler/types.rs
+++ b/src/handler/types.rs
@@ -452,6 +452,85 @@ impl TryFrom<&str> for BlockNum {
     }
 }
 
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, From, Default, Mul, Div, Add, AddAssign,
+)]
+pub struct BlockInterval(pub i128);
+
+impl Div<BlockInterval> for BlockInterval {
+    type Output = BlockInterval;
+
+    fn div(self, rhs: BlockInterval) -> Self::Output {
+        BlockInterval(self.0 / rhs.0)
+    }
+}
+
+impl PartialEq<u64> for BlockInterval {
+    fn eq(&self, other: &u64) -> bool {
+        self.0.eq(&i128::from(*other))
+    }
+}
+
+impl PartialOrd<u64> for BlockInterval {
+    fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&i128::from(*other))
+    }
+}
+
+impl PartialEq<BlockInterval> for u64 {
+    fn eq(&self, other: &BlockInterval) -> bool {
+        i128::from(*self).eq(&other.0)
+    }
+}
+
+impl PartialOrd<BlockInterval> for u64 {
+    fn partial_cmp(&self, other: &BlockInterval) -> Option<std::cmp::Ordering> {
+        i128::from(*self).partial_cmp(&other.0)
+    }
+}
+
+impl From<u64> for BlockInterval {
+    fn from(val: u64) -> Self {
+        Self(val.into())
+    }
+}
+
+impl BlockInterval {
+    pub fn from_blocknum(num: BlockNum) -> Self {
+        Self(num.0.into())
+    }
+}
+
+impl fmt::Display for BlockInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl PartialEq<BlockNum> for BlockInterval {
+    fn eq(&self, other: &BlockNum) -> bool {
+        self.0 == i128::from(other.0)
+    }
+}
+
+impl PartialOrd<BlockNum> for BlockInterval {
+    fn partial_cmp(&self, other: &BlockNum) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&i128::from(other.0))
+    }
+}
+
+impl PartialEq<BlockInterval> for BlockNum {
+    fn eq(&self, other: &BlockInterval) -> bool {
+        i128::from(self.0) == other.0
+    }
+}
+
+impl PartialOrd<BlockInterval> for BlockNum {
+    fn partial_cmp(&self, other: &BlockInterval) -> Option<std::cmp::Ordering> {
+        i128::from(self.0).partial_cmp(&other.0)
+    }
+}
+
 #[test]
 fn try_from_str_for_blocknum_works_as_expected() {
     assert_eq!(BlockNum::try_from("8").unwrap(), BlockNum(8));

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -17,12 +17,12 @@ use crate::handler::constants::{
 
 use super::constants::INTEREST_MULTIPLIER;
 use super::constants::INVALID_NUMBER_FORMAT_ERR;
-use super::types::BlockNum;
 use super::types::CurrencyAmount;
 use super::types::State;
 use super::types::StateVec;
 use super::types::WalletId;
 use super::types::{Address, CCApplyError};
+use super::types::{BlockInterval, BlockNum};
 use super::types::{SigHash, TxnResult};
 use super::HandlerContext;
 
@@ -293,16 +293,16 @@ pub fn add_fee_state(
 
 pub fn calc_interest(
     amount: &CurrencyAmount,
-    ticks: BlockNum,
+    ticks: BlockInterval,
     interest: &CurrencyAmount,
 ) -> CurrencyAmount {
     let mut total = amount.clone();
-    let mut i = BlockNum(0);
+    let mut i = 0;
 
     while i < ticks {
         let compound = (total.clone() * interest) / INTEREST_MULTIPLIER;
         total += compound;
-        i += BlockNum(1);
+        i += 1;
     }
     total
 }


### PR DESCRIPTION
## Description Of Changes
Currently we represent block numbers (and calculations based off of them) with unsigned integers, as a negative block number is meaningless. Built into this choice was the assumption that we would never deal with negative block _intervals_. This is generally true, as we usually compute the number of blocks elapsed between the current block and block in the past. There is one case, however, when we calculate the number of blocks relative to a block in the past, not the current block -- when a housekeeping transaction is submitted with a non-zero block index. E.g. from the housekeeping code:

```rust

let start = ask_order.block;
let elapsed = block_idx - start;
```
If `block_idx` is less than `start`, than we would overflow and issue an error. In production, non-zero housekeeping transactions have not been produced in a long time, so this was never excersized, and evidently there were not explicit unit tests for this case. 

This PR fixes this by introducing a block interval type which is allowed to be negative and is produced by subtraction between block numbers. This way we still uphold the invariant that block numbers are non-negative, but negative block intervals are not an error.

I have also added a test for non-zero housekeeping transaction that also exercises this case

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [ ] All CI checks reports PASS

