### PR TITLE
[CRB-293] Fix bug in validation of hex strings

### DIFF
--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -153,7 +153,18 @@ pub fn sha512<B: AsRef<[u8]>>(bytes: B) -> String {
 }
 
 pub fn is_hex(s: &str) -> bool {
-    s.contains(|c: char| !(c.is_numeric() || ('a'..'f').contains(&c) || ('A'..'F').contains(&c)))
+    s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[test]
+fn is_hex_accepts_hex() {
+    assert!(is_hex("abcdefABCDEF1234567890"));
+    assert!(is_hex(""));
+}
+
+#[test]
+fn is_hex_rejects_nonhex() {
+    assert!(!is_hex("g1234567890"));
 }
 
 pub fn compress(uncompressed: &str) -> TxnResult<String> {


### PR DESCRIPTION
## Description Of Changes
This PR fixes a (somewhat embarrassing) bug in the implementation of the `is_hex` utility function. The original code checked if all characters are in the range `'a'..'f'` which incorrectly excludes 'f'. The function is now corrected and simplified, and a couple of unit tests are added to confirm the proper behavior.

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [x] All CI checks reports PASS

