### PR TITLE
Allow empty block num when deserializing transaction

### DIFF
--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -124,6 +124,25 @@ pub fn get_block_num(map: &BTreeMap<Value, Value>, key: &str, name: &str) -> Txn
     }
 }
 
+#[test]
+fn get_block_num_basic() {
+    let mut map = BTreeMap::new();
+    map.insert(Value::Text("key".into()), Value::Text("3".into()));
+
+    assert_eq!(
+        get_block_num(&map, "key", "name").unwrap(),
+        BlockNum::from(3)
+    );
+}
+
+#[test]
+fn get_block_num_empty_string() {
+    let mut map = BTreeMap::new();
+    map.insert(Value::Text("key".into()), Value::Text(String::new()));
+
+    assert_eq!(get_block_num(&map, "key", "name").unwrap(), BlockNum::new());
+}
+
 pub fn to_hex_string(bytes: &[u8]) -> String {
     let mut buf = String::with_capacity(2 * bytes.len());
     for b in bytes {

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -117,7 +117,11 @@ pub fn get_u64(map: &BTreeMap<Value, Value>, key: &str, name: &str) -> TxnResult
 
 pub fn get_block_num(map: &BTreeMap<Value, Value>, key: &str, name: &str) -> TxnResult<BlockNum> {
     let str_value = get_string(map, key, name)?;
-    BlockNum::try_from(str_value)
+    if str_value.is_empty() {
+        Ok(BlockNum::new())
+    } else {
+        BlockNum::try_from(str_value)
+    }
 }
 
 pub fn to_hex_string(bytes: &[u8]) -> String {


### PR DESCRIPTION
## Description Of Changes
Some legacy transactions (housekeeping for the most part) leave the `block_num` field of protobufs with the default value - an empty string. This is equivalent to a value of '0' but currently fails in deserialization. This PR makes it so we now accept an empty string for `block_num` and translate it to a value of 0.

## Code Review Checklist

- [ ] Target branch is `dev`, unless we're merging from `dev` to `main`
- [ ] All CI checks reports PASS

