### PR TITLE
Fix inverted branch in award function

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -54,6 +54,7 @@ pub trait ErrorExt: Sized {
     type Return;
     fn to_apply_error(self) -> Self::Return;
 
+    #[must_use]
     fn log_err(self) -> Self;
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2007,7 +2007,7 @@ fn award(
         let pos = fraction_str.find('.').unwrap();
         assert!(pos > 0);
 
-        let fraction_in_wei_str = if fraction_str.starts_with('0') {
+        let fraction_in_wei_str = if !fraction_str.starts_with('0') {
             format!("{}{:0<18}", &fraction_str[..pos], &fraction_str[pos + 1..])
         } else {
             let mut pos = 2;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2007,9 +2007,7 @@ fn award(
         let pos = fraction_str.find('.').unwrap();
         assert!(pos > 0);
 
-        let fraction_in_wei_str = if !fraction_str.starts_with('0') {
-            format!("{}{:0<18}", &fraction_str[..pos], &fraction_str[pos + 1..])
-        } else {
+        let fraction_in_wei_str = if fraction_str.starts_with('0') {
             let mut pos = 2;
             for c in fraction_str.bytes().skip(pos) {
                 if c == b'0' {
@@ -2019,6 +2017,8 @@ fn award(
                 }
             }
             format!("{:0<width$}", &fraction_str[pos..], width = 20 - pos)
+        } else {
+            format!("{}{:0<18}", &fraction_str[..pos], &fraction_str[pos + 1..])
         };
 
         reward.assign(Credo::try_parse(&fraction_in_wei_str)? * 28);

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1444,7 +1444,7 @@ impl CCTransaction for RegisterDealOrder {
             Err(err) => {
                 return Err(anyhow::Error::from(InvalidTransaction(format!(
                     "Error occurred when verifying the fundraiser signature : {}",
-                    err.to_string()
+                    err
                 ))))
                 .with_context(|| {
                     format!(

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3227,7 +3227,7 @@ fn housekeeping_reward_in_chain() {
     // from height_start to height_end in order to issue mining rewards
     // return a dummy signer
     for height in height_start.0..height_end.0 {
-        let signer = format!("signer{}", height);
+        let signer = format!("02{:0<64}", height);
         signers.push(signer.clone());
         expect!(tx_ctx,
             get_sig_by_num(h if *h == height) -> Ok(signer)
@@ -3310,7 +3310,7 @@ fn housekeeping_reward_fork() {
     log::warn!("{}..{}", last_pred, first_pred);
 
     let signers: Vec<String> = (last_pred.0..first_pred.0)
-        .map(|i| format!("signer{}", i))
+        .map(|i| format!("02{:0<64}", i))
         .collect();
 
     let signers_ = signers.clone();

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -384,6 +384,24 @@ fn calc_reward(new_formula: bool, block_idx: BlockNum) -> TxnResult<Credo> {
     Ok(reward.into())
 }
 
+#[test]
+fn reward_calculation_old_formula() {
+    assert_eq!(calc_reward(false, BlockNum(1)).unwrap(), &*REWARD_AMOUNT);
+}
+
+#[test]
+fn reward_calculation_new_formula() {
+    assert_eq!(
+        calc_reward(true, BlockNum(1)).unwrap(),
+        Credo::try_parse("1_000_000_000_000_000_000").unwrap() * 28
+    );
+
+    assert_eq!(
+        calc_reward(true, BLOCKS_IN_PERIOD_UPDATE1).unwrap(),
+        Credo::try_parse("950_000_000_000_000_000").unwrap() * 28
+    );
+}
+
 pub(crate) fn award(
     tx_ctx: &dyn TransactionContext,
     new_formula: bool,

--- a/src/handler/utils.rs
+++ b/src/handler/utils.rs
@@ -381,7 +381,7 @@ fn calc_reward(new_formula: bool, block_idx: BlockNum) -> TxnResult<Credo> {
     } else {
         reward.assign(&*REWARD_AMOUNT);
     }
-    Ok(reward.into())
+    Ok(reward)
 }
 
 #[test]


### PR DESCRIPTION
## Description Of Changes
There is a typo in the award function when using the new formula that inverts a branch. This causes errors in revalidation or syncing with the production chain from scratch.

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [x] All CI checks reports PASS

