### PR TITLE
Allow housekeeping to run if gateway sighash isn't set

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2074,12 +2074,14 @@ fn verify_gateway_signer(my_sighash: &str, ctx: &mut HandlerContext) -> TxnResul
     if let Some(val) = s {
         if val == my_sighash {
             return Ok(());
+        } else {
+            bail_transaction!(
+                "Restricted transaction",
+                context = "Only a priveleged user can run Housekeeping with a non-zero parameter"
+            );
         }
     }
-    bail_transaction!(
-        "Restricted transaction",
-        context = "Only a priveleged user can run Housekeeping with a non-zero parameter"
-    );
+    Ok(())
 }
 
 impl CCTransaction for Housekeeping {


### PR DESCRIPTION
## Description Of Changes
This PR makes it so housekeeping can still run if the gateway sighash setting isn't set, which is the case in legacy blocks. This change is necessary for revalidation to succeed.

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [x] All CI checks reports PASS

