### PR TITLE
Skip filtering fees if less than one year of blocks has elapsed

### DIFF
--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3675,10 +3675,6 @@ fn housekeeping_removes_expired_entries() {
         expect_delete_state_entry(&mut tx_ctx, string!(&repay, "shouldbedeleted"));
     }
 
-    {
-        expect_get_state_entries_by_prefix::<protos::Fee>(&mut tx_ctx, request.tip, &fee, vec![]);
-    }
-
     tx_ctx
         .expect_get_reward_block_signatures()
         .once()

--- a/src/handler/tests.rs
+++ b/src/handler/tests.rs
@@ -3531,7 +3531,6 @@ fn housekeeping_removes_expired_entries() {
     let offer = string!(NAMESPACE_PREFIX, OFFER);
     let deal = string!(NAMESPACE_PREFIX, DEAL_ORDER);
     let repay = string!(NAMESPACE_PREFIX, REPAYMENT_ORDER);
-    let fee = string!(NAMESPACE_PREFIX, FEE);
 
     expect_get_last_processed_block(&mut tx_ctx, last_processed);
 


### PR DESCRIPTION
## Description Of Changes
This PR implements an optimization for housekeeping transactions run during validation. We only refund fees after one year of blocks, so we can skip the expensive filter operation if one year hasn't elapsed. This speeds up revalidation substantially.

## Code Review Checklist

- [x] Target branch is `dev`, unless we're merging from `dev` to `main`
- [x] All CI checks reports PASS

